### PR TITLE
fix camera interface reset image dimensions bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "l2r"
-version = "0.0.1"
+version = "0.0.2"
 description = "a OpenAI gym environment for high performance autonomous racing"
 readme = "README.md"
 authors = [

--- a/test/core/test_interface.py
+++ b/test/core/test_interface.py
@@ -2,6 +2,8 @@ import unittest
 from unittest import mock
 
 from l2r.core import ActionInterface
+from l2r.core import CameraConfig
+from l2r.core import CameraInterface
 from l2r.core.interfaces import InvalidActionError
 
 
@@ -59,7 +61,7 @@ class ActionInterfaceTest(unittest.TestCase):
         self.assertAlmostEqual(scaled_accel, 0.9)
 
 
-class PoseInterface(unittest.TestCase):
+class PoseInterfaceTest(unittest.TestCase):
     """
     Tests associated with the l2r position interface
     """
@@ -67,9 +69,21 @@ class PoseInterface(unittest.TestCase):
     pass
 
 
-class CameraInterface(unittest.TestCase):
+class CameraInterfaceTest(unittest.TestCase):
     """
     Tests associated with the l2r camera interface
     """
 
-    pass
+    cfg = CameraConfig(Width=256, Height=192)
+    mock_socket = mock.MagicMock()
+
+    def test_img_dims_on_reset(self):
+        """Validate images received are of shape (H, W, 3)"""
+        camera_if = CameraInterface(cfg=self.cfg, socket=self.mock_socket)
+        camera_if.reset()
+        img = camera_if.get_data()
+        self.assertEqual(img.shape, (192, 256, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`l2r.core.interfaces.CameraInterface` returns an image of shape (width, height, 3) on `reset()` instead of the expected (height, width, 3)